### PR TITLE
AddingPowerSupport_CI/Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,12 @@ language: go
 go:
   - tip
   - 1.9
+jobs:
+ exclude:
+  - go: 1.9
+    arch: amd64
+  - go: 1.9
+    arch: ppc64le
 script: 
   - go get golang.org/x/lint/golint
   - go get golang.org/x/tools/cmd/cover

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+arch:
+   - amd64
+   - ppc64le
 sudo: false
 language: go
 go:


### PR DESCRIPTION
Adding power support.

Adding power support ppc64le with Continues Integration/testing so that code remains architecture independent.

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.

The build is successful on both arch: amd64/ppc64le, please find the Travis Link below.
https://travis-ci.com/github/santosh653/goutils

Please let me know if you need any further details? or if I am missing any.

Thank You !!